### PR TITLE
ci: fixing release issue

### DIFF
--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -16,7 +16,6 @@ jobs:
       chartName: common
       additionalTestFilesCommand: ''
       chartRepos: 'bitnami=https://charts.bitnami.com/bitnami,openfga=https://openfga.github.io/helm-charts'
-      skipVulnerabilityScan: false
     secrets: inherit
 
   updateVersionFile:


### PR DESCRIPTION
the skip vulnerability option prevented new common releases to be published. I've removed the option in the reuse workflow.