### PR TITLE
fix (template): remove call to "common.entity.name" from other common templates

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart containing reuse templates
 
 type: library
 
-version: 0.2.6
+version: 0.2.7

--- a/charts/common/templates/_deploymentHelpers.tpl
+++ b/charts/common/templates/_deploymentHelpers.tpl
@@ -137,8 +137,6 @@ securityContext:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
-serviceAccountName: {{ include "common.entity.name" . }}
-automountServiceAccountToken: {{ not (eq (.Values.security).mountServiceAccountToken false) }}
 {{- end }}
 
 {{- define "common.spec.securityContext" -}}


### PR DESCRIPTION
## Description
Calling "common.entity.name" can cause issues with multiple dependency charts by evaluating the .Chart.Name and .Release.Name differently, depending on the evaluation context. Also, it is bad practice to include ServiceAccount fields in the securityContext

related to https://github.com/openmfp/helm-charts/issues/164