### PR TITLE
fix (wf): run localsetup check on main branch

### DIFF
--- a/.github/workflows/kind-localsetup.yaml
+++ b/.github/workflows/kind-localsetup.yaml
@@ -5,6 +5,9 @@ on:
       - '**'
     paths:
       - 'local-setup/**'
+  push:
+    branches:
+      - 'main'
 
 concurrency:
   group: localsetup-${{ github.ref }}


### PR DESCRIPTION
If a chart is changed in the PR, the changes will not be used in the localsetup check. It must also run on `main` branch, after the chart is published.