### PR TITLE
[Fix]:Reuse API update Pull Request

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,9 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: helm-charts
-Upstream-Contact: 
-Source: https://github.com/openmfp/helm-charts
-
-Files: *
-Copyright: 2024 SAP SE or an SAP affiliate company and openMFP contributors and helm-charts contributors.
-License: Apache-2.0
-

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,9 @@
+version = 1
+SPDX-PackageName = "helm-charts"
+SPDX-PackageDownloadLocation = "https://github.com/openmfp/helm-charts"
+
+[[annotations]]
+path = "**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 SAP SE or an SAP affiliate company and openMFP contributors and helm-charts contributors."
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
The PR is fixing and updating the Reuse compliance to match the recent Reuse API Specification - we remove the dep5 file and migrate to the toml file. For more details please read the [Reuse Specification](https://reuse.software/spec-3.3/)