### PR TITLE
chore: changed the name of CRD_GATEWAY_API_URL env variable

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm Chart for the openmfp Portal
 name: portal
-version: 0.73.41
+version: 0.73.42
 appVersion: "v0.377.16"
 dependencies:
   - name: common

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -14,7 +14,7 @@ Helm Chart for the openmfp Portal
 | cookieDomain | string | `"localhost"` | cookie domain |
 | developmentLandcsape | string | `"true"` | development landscape toggle |
 | environment | string | `"local"` | environment |
-| extraEnvVars | list | `[{"name":"CRD_GATEWAY_API_URL","value":"http://localhost:8000/example-gateway/graphql"}]` | A way to provide additional experimental environment variables |
+| extraEnvVars | list | `[{"name":"KUBERNETES_GRAPHQL_GATEWAY_API_URL","value":"http://localhost:8000/example-gateway/graphql"}]` | A way to provide additional experimental environment variables |
 | featureToggles | string | `"enableSessionAutoRefresh=true"` |  |
 | frontendPort | int | `8000` | frontend port |
 | health.liveness.path | string | `"/rest/health"` | path used for the liveness probe |

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -35,7 +35,7 @@ cookieDomain: "localhost"
 
 # -- A way to provide additional experimental environment variables
 extraEnvVars:
-  - name: CRD_GATEWAY_API_URL
+  - name: KUBERNETES_GRAPHQL_GATEWAY_API_URL
     value: http://localhost:8000/example-gateway/graphql
 
 trust:


### PR DESCRIPTION
This is a part of PRs:
https://github.com/openmfp/helm-charts-priv/pull/1226/files (this PR also includes update for openmfp-priv chart)
https://github.com/openmfp/portal/pull/417/files
https://github.com/openmfp/helm-charts/pull/524