### PR TITLE
fix: issue GH_TOKEN via the publisher app

### DIFF
--- a/.github/workflows/kind-localsetup.yaml
+++ b/.github/workflows/kind-localsetup.yaml
@@ -14,6 +14,14 @@ jobs:
     runs-on: ubuntu-latest-large
 
     steps:
+      # Step 0: Generate a GitHub token
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: "838464"
+          private-key: ${{ secrets.OPENMFP_PUBLISHER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       # Step 1: Checkout the code
       - uses: actions/checkout@v4
 
@@ -39,8 +47,7 @@ jobs:
         name: Run start.sh
         id: run_start_sh
         env:
-          # GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_USER: ${{ github.repository_owner }}
           DEBUG: true
         run: |

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -70,3 +70,6 @@ tasks:
     cmds:
       - "rm oci/* || true"
       - task: helmpackage
+  local-setup:
+    cmds:
+      - "./local-setup/scripts/start.sh"

--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -49,6 +49,7 @@ To start the bootstrapping and local installation invoke
 ./local-setup/scripts/start.sh
 ```
 
+
 Once the process is completed you can access the environment using http://localhost:8000
 
 # Optional Steps


### PR DESCRIPTION
Fixes local-setup after removed secrets.GH_ACCESS_TOKEN in repo settings.