### PR TITLE
fix (ci): always trigger required checks for PRs

### DIFF
--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -5,9 +5,6 @@ on:
       - 'charts/common/**'
       - '.github/workflows/common.yaml'
   pull_request:
-    paths:
-      - 'charts/common/**'
-      - '.github/workflows/common.yaml'
 
 jobs:
   pipeline:

--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -5,6 +5,9 @@ on:
       - 'charts/common/**'
       - '.github/workflows/common.yaml'
   pull_request:
+    paths:
+      - 'charts/common/**'
+      - '.github/workflows/common.yaml'
 
 jobs:
   pipeline:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,0 +1,40 @@
+name: PR Checks workflow
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: localsetup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  checkdiff:
+    concurrency:
+      group: common-${{ github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    outputs:
+      helmcharts: ${{ steps.changed-chart-files.outputs.helmcharts_any_changed }}
+    steps:
+      - name: Get changed files for charts
+        id: changed-chart-files
+        uses: step-security/changed-files@v45
+        with:
+          files_yaml: |
+            helmcharts:
+              - charts/**
+
+  pipeline:
+    needs: checkdiff
+    if: ${{ needs.checkdiff.outputs.helmcharts == 'false' }}
+    concurrency:
+      group: common-${{ github.ref }}
+      cancel-in-progress: true
+    uses: openmfp/gha/.github/workflows/pipeline-chart.yml@main
+    with:
+      chartFolder: charts
+      chartName: common
+      additionalTestFilesCommand: ''
+      chartRepos: 'bitnami=https://charts.bitnami.com/bitnami,openfga=https://openfga.github.io/helm-charts'
+    secrets: inherit


### PR DESCRIPTION
Some renovate PRs (https://github.com/openmfp/helm-charts/pull/532) aren't merged due to this.