### PR TITLE
feat(keycloak): adding envoy filter to set x-forwarded-port header

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak
 description: A Helm chart to deploy keycloak as OIDC provider in openmfp
 
 type: application
-version: 0.62.14
+version: 0.63.0
 appVersion: "1.16.0"
 
 dependencies:

--- a/charts/keycloak/templates/envoy-filter.yaml
+++ b/charts/keycloak/templates/envoy-filter.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: add-x-forwarded-port
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      app.kubernetes.io/component: keycloak
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.lua
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+            inlineCode: |
+              function envoy_on_request(request_handle)
+                local port = request_handle:headers():get(":authority"):match(":(%d+)$")
+                if port then
+                  request_handle:headers():add("x-forwarded-port", port)
+                end
+              end


### PR DESCRIPTION
istio sets the x-forwarded-for header by default but not the x-forwarded-port.

Keycloak can use the x-forwarded-port header to redirect to the correct port for cases where a different port then 80/443 is used.