### PR TITLE
fix: update apiVersion for external secrets to v1 and bump chart versions for keycloak and portal

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak
 description: A Helm chart to deploy keycloak as OIDC provider in openmfp
 
 type: application
-version: 0.64.5
+version: 0.64.6
 appVersion: "1.16.0"
 
 dependencies:

--- a/charts/keycloak/templates/crossplane/external-secrets.yaml
+++ b/charts/keycloak/templates/crossplane/external-secrets.yaml
@@ -1,7 +1,7 @@
 {{- if eq (include "common.getNestedValue" (dict "Values" .Values "key" "crossplane.enabled")) "true" -}}
 {{- if eq (include "common.getKeyValue" (dict "Values" .Values "key" "externalSecrets.enabled")) "true" -}}
 {{- range $key, $val := .Values.crossplane.identityProviders }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "common.entity.name" $ }}-{{ $key }}
@@ -23,7 +23,7 @@ spec:
         conversionStrategy: Default
 ---
 {{ end -}}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "common.entity.name" . }}-provider-config

--- a/charts/keycloak/templates/external-secrets.yaml
+++ b/charts/keycloak/templates/external-secrets.yaml
@@ -1,5 +1,5 @@
 {{- if eq (include "common.getKeyValue" (dict "Values" .Values "key" "externalSecrets.enabled")) "true" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "common.entity.name" . }}-admin
@@ -22,7 +22,7 @@ spec:
 
 ---
 
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "common.entity.name" . }}-postgres

--- a/charts/keycloak/tests/__snapshot__/external-secrets_test.yaml.snap
+++ b/charts/keycloak/tests/__snapshot__/external-secrets_test.yaml.snap
@@ -1,6 +1,6 @@
 matches the snapshot:
   1: |
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
       name: RELEASE-NAME-keycloak-admin
@@ -21,7 +21,7 @@ matches the snapshot:
         deletionPolicy: Retain
         name: keycloak-admin
   2: |
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
       name: RELEASE-NAME-keycloak-postgres

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm Chart for the openmfp Portal
 name: portal
-version: 0.73.210
+version: 0.73.211
 appVersion: "v0.377.183"
 dependencies:
   - name: common

--- a/charts/portal/templates/external-secrets.yaml
+++ b/charts/portal/templates/external-secrets.yaml
@@ -8,7 +8,7 @@
   {{- end }}
 {{- end }}
 {{- range $key := $secretKeys }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $.Release.Name }}-portal-client-secret-{{ $key }}


### PR DESCRIPTION
refers to https://github.com/openmfp/helm-charts/issues/870