### PR TITLE
chore(extension-content-operator): add sidecar

### DIFF
--- a/charts/extension-manager-operator/templates/sidecar.yaml
+++ b/charts/extension-manager-operator/templates/sidecar.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Sidecar
+metadata:
+  name: extension-content-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  outboundTrafficPolicy:
+    mode: ALLOW_ANY
+  workloadSelector:
+    labels:
+      {{- include "common.labelMatcher" . | indent 6 }}

--- a/charts/extension-manager-operator/tests/__snapshot__/sidecar_test.yaml.snap
+++ b/charts/extension-manager-operator/tests/__snapshot__/sidecar_test.yaml.snap
@@ -1,0 +1,13 @@
+match the snapshot:
+  1: |
+    apiVersion: networking.istio.io/v1beta1
+    kind: Sidecar
+    metadata:
+      name: extension-content-operator
+      namespace: NAMESPACE
+    spec:
+      outboundTrafficPolicy:
+        mode: ALLOW_ANY
+      workloadSelector:
+        labels:
+          app: RELEASE-NAME-extension-manager-operator

--- a/charts/extension-manager-operator/tests/sidecar_test.yaml
+++ b/charts/extension-manager-operator/tests/sidecar_test.yaml
@@ -1,0 +1,10 @@
+suite: platform-mesh istio sidecar
+templates:
+  - sidecar.yaml
+tests:
+- it: match the snapshot
+  values:
+    - ../values.yaml
+    - ../test-values.yaml
+  asserts:
+    - matchSnapshot: { }


### PR DESCRIPTION
we have the pod extension-content-operator-extension-manager-operator reconciling 'ContentConfiguration'
currently it fails for configurations pointing to configurations outside the cluster example:

We need to add a sidecar for allowing the operator to have ALLOW_ANY as outbound traffic

```
kind: ContentConfiguration
spec:
  remoteConfiguration:
    contentType: json
    url: https://a-public-facing-url/hyperspace-portal-config.json
status:
  conditions:
  - lastTransitionTime: "2025-08-19T08:28:39Z"
    message: The resource is not ready
    reason: Complete
    status: "False"
    type: Ready
  - lastTransitionTime: "2025-08-19T08:28:39Z"
    message: 'The subroutine has an error: request failed: Get "https://a-public-facing-url/hyperspace-portal-config.json":
      read tcp xxxxxx:54394->xxxxx:443: read: connection reset by peer'
    reason: Error
    status: "False"
    type: ContentConfigurationSubroutine_Ready
```
 